### PR TITLE
Fix multiple-value in single-value context error

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func main() {
 	// install the default apparmor profile
 	if apparmor.IsEnabled() {
 		// check if we have the docker-default apparmor profile loaded
-		if err := aaprofile.IsLoaded(defaultApparmorProfile); err != nil {
+		if _, err := aaprofile.IsLoaded(defaultApparmorProfile); err != nil {
 			logrus.Warnf("AppArmor enabled on system but the %s profile is not loaded. apparmor_parser needs root to load a profile so we can't do it for you.", defaultApparmorProfile)
 		} else {
 			spec.Process.ApparmorProfile = defaultApparmorProfile


### PR DESCRIPTION
For `aaprofile.IsLoaded()` on line 186 in `main.go` the function returns two value but only one was assigned. Therefore `make static` was failing with following error:
`./main.go:186: multiple-value "github.com/docker/docker/profiles/apparmor".IsLoaded() in single-value context`

Also, `github.com/docker/docker/profiles/apparmor` is missing from `vendor/manifest`, the fix will follow up in other PR.